### PR TITLE
Add more Google machine types

### DIFF
--- a/google-cloud-platform/files/shapes.yaml
+++ b/google-cloud-platform/files/shapes.yaml
@@ -13,7 +13,49 @@ n1-standard-2:
   threads_per_core: 2
 
 n1-standard-4:
-  memory: 14000
+  memory: 14200
   sockets: 1
   cores_per_socket: 2
+  threads_per_core: 2
+
+n1-standard-8:
+  memory: 29000
+  sockets: 1
+  cores_per_socket: 4
+  threads_per_core: 2
+
+n1-standard-16:
+  memory: 58000
+  sockets: 1
+  cores_per_socket: 8
+  threads_per_core: 2
+
+n1-standard-32:
+  memory: 118400
+  sockets: 1
+  cores_per_socket: 16
+  threads_per_core: 2
+
+n1-standard-64:
+  memory: 238000
+  sockets: 1
+  cores_per_socket: 32
+  threads_per_core: 2
+
+c2-standard-4:
+  memory: 14200
+  sockets: 1
+  cores_per_socket: 2
+  threads_per_core: 2
+
+c2-standard-8:
+  memory: 31000
+  sockets: 1
+  cores_per_socket: 4
+  threads_per_core: 2
+
+c2-standard-16:
+  memory: 62824
+  sockets: 1
+  cores_per_socket: 8
   threads_per_core: 2


### PR DESCRIPTION
I've had a hard time booting any of the larger shapes in europe-west4-{b,c}

-  n1-standard-96
- c2-standard-30
- c2-standard-60

So I've left them off for the moment

The c2-* shapes won't actually work until https://github.com/ACRC/slurm-ansible-playbook/issues/66 is resolved