### PR TITLE
Move to IAM instance roles, instead of copying local creds to EC2

### DIFF
--- a/aws/compute.tf
+++ b/aws/compute.tf
@@ -1,3 +1,4 @@
+
 data "aws_ami" "centos7" {
   # See http://cavaliercoder.com/blog/finding-the-latest-centos-ami.html
   # https://wiki.centos.org/Cloud/AWS
@@ -21,15 +22,15 @@ locals {
 }
 
 resource "aws_instance" "mgmt" {
-  ami           = data.aws_ami.centos7.id
-  instance_type = var.management_shape
-  vpc_security_group_ids = [aws_security_group.mgmt.id]
-  subnet_id = aws_subnet.vpc_subnetwork.id
+  ami                         = data.aws_ami.centos7.id
+  instance_type               = var.management_shape
+  vpc_security_group_ids      = [aws_security_group.mgmt.id]
+  subnet_id                   = aws_subnet.vpc_subnetwork.id
   associate_public_ip_address = true
-  iam_instance_profile = aws_iam_instance_profile.describe_tags.id
+  iam_instance_profile        = aws_iam_instance_profile.manage_ec2.id
 
   user_data = data.template_file.bootstrap-script.rendered
-  key_name = aws_key_pair.ec2-user.key_name
+  key_name  = aws_key_pair.ec2-user.key_name
 
   depends_on = [aws_efs_mount_target.shared, aws_key_pair.ec2-user, aws_route53_record.shared, aws_route.internet_route]
 
@@ -50,13 +51,8 @@ resource "aws_instance" "mgmt" {
     content     = data.template_file.startnode-yaml.rendered
   }
 
-  provisioner "file" {
-    destination = "/tmp/aws-credentials.csv"
-    source      = pathexpand(var.aws_shared_credentials)
-  }
-
   tags = {
-    Name = local.mgmt_hostname
+    Name    = local.mgmt_hostname
     cluster = local.cluster_id
   }
 }

--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -1,10 +1,10 @@
-resource "aws_iam_instance_profile" "describe_tags" {
-  name = "describe_tags-${local.cluster_id}"
-  role = aws_iam_role.describe_tags.name
+resource "aws_iam_instance_profile" "manage_ec2" {
+  name = "manage_ec2_${local.cluster_id}"
+  role = aws_iam_role.manage_ec2.name
 }
 
-resource "aws_iam_role" "describe_tags" {
-  name = "describe_tags-${local.cluster_id}"
+resource "aws_iam_role" "manage_ec2" {
+  name = "manage_ec2_${local.cluster_id}"
   path = "/"
 
   assume_role_policy = <<EOF
@@ -24,27 +24,52 @@ resource "aws_iam_role" "describe_tags" {
 EOF
 
   tags = {
-    Name = "citc-describe_tags-${local.cluster_id}"
+    Name    = "manage_ec2_${local.cluster_id}"
     cluster = local.cluster_id
   }
 }
 
-resource "aws_iam_role_policy" "describe_tags" {
-  name = "describe_tags-${local.cluster_id}"
-  role = aws_iam_role.describe_tags.id
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "ec2:DescribeTags"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
+resource "aws_iam_role_policy" "manage_ec2" {
+  name   = "manage_ec2_${local.cluster_id}"
+  role   = aws_iam_role.manage_ec2.id
+  policy = "${data.aws_iam_policy_document.manage_ec2.json}"
 }
-EOF
+
+data "aws_iam_policy_document" "manage_ec2" {
+  statement {
+    sid = "1"
+
+    actions = [
+      "ec2:DescribeTags",
+      "ec2:DescribeInstances",
+      "ec2:DescribeImages",
+      "ec2:RunInstances",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    sid = "2"
+
+    actions = [
+      "ec2:TerminateInstances",
+      "route53:ChangeResourceRecordSets",
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "iam:ResourceTag/cluster"
+
+      values = [
+        local.cluster_id
+      ]
+    }
+  }
 }

--- a/aws/provider.tf
+++ b/aws/provider.tf
@@ -24,6 +24,5 @@ provider "null" {
 
 provider "aws" {
   version     = "2.16.0"
-  profile     = var.profile  # refer to ~/.aws/credentials
   region      = var.region
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -28,7 +28,3 @@ variable "private_key_path" {
 variable "ansible_branch" {
   default = "5"
 }
-
-variable "aws_shared_credentials" {
-  default = "~/.aws/credentials"
-}


### PR DESCRIPTION
Switch to using IAM instance roles in the interest of security, and to better support federated AWS API access. 

Tested with main repo Centos8 branch and AWS CLI installed on mgmt node. Will need further testing and updated to Ansible provisioning scripts. 