### PR TITLE
Upgrade Oracle to Oracle Linux 8

### DIFF
--- a/oracle/compute.tf
+++ b/oracle/compute.tf
@@ -1,15 +1,33 @@
-data "oci_core_images" "ol7" {
-    compartment_id = var.compartment_ocid
+data "oci_core_app_catalog_listings" "ol8" {
+  publisher_name = "Oracle Linux"
+  filter {
+    name   = "display_name"
+    values = ["^Oracle Linux 8.([\\.0-9-]+)$"]
+    regex  = true
+  }
+}
 
-    operating_system = "Oracle Linux"
-    operating_system_version = "7.8"
+data "oci_core_app_catalog_listing_resource_versions" "ol8" {
+  listing_id = data.oci_core_app_catalog_listings.ol8.app_catalog_listings[0].listing_id
+}
 
-    # exclude GPU specific images
-    filter {
-        name   = "display_name"
-        values = ["^([a-zA-z]+)-([a-zA-z]+)-([\\.0-9]+)-([\\.0-9-]+)$"]
-        regex  = true
-    }
+resource "oci_core_app_catalog_listing_resource_version_agreement" "ol8" {
+  listing_id               = data.oci_core_app_catalog_listing_resource_versions.ol8.app_catalog_listing_resource_versions[0].listing_id
+  listing_resource_version = data.oci_core_app_catalog_listing_resource_versions.ol8.app_catalog_listing_resource_versions[0].listing_resource_version
+}
+
+resource "oci_core_app_catalog_subscription" "ol8" {
+  compartment_id           = var.tenancy_ocid
+  eula_link                = oci_core_app_catalog_listing_resource_version_agreement.ol8.eula_link
+  listing_id               = oci_core_app_catalog_listing_resource_version_agreement.ol8.listing_id
+  listing_resource_version = oci_core_app_catalog_listing_resource_version_agreement.ol8.listing_resource_version
+  oracle_terms_of_use_link = oci_core_app_catalog_listing_resource_version_agreement.ol8.oracle_terms_of_use_link
+  signature                = oci_core_app_catalog_listing_resource_version_agreement.ol8.signature
+  time_retrieved           = oci_core_app_catalog_listing_resource_version_agreement.ol8.time_retrieved
+
+  timeouts {
+    create = "20m"
+  }
 }
 
 locals {
@@ -38,7 +56,7 @@ resource "oci_core_instance" "ClusterManagement" {
 
   source_details {
     source_type = "image"
-    source_id   = data.oci_core_images.ol7.images.0.id
+    source_id   = oci_core_app_catalog_subscription.ol8.listing_resource_id
   }
 
   metadata = {
@@ -133,6 +151,7 @@ ad_root: ${substr(
 )}
 ansible_branch: ${var.ansible_branch}
 cluster_id: ${local.cluster_id}
+mgmt_image_id: ${oci_core_app_catalog_subscription.ol8.listing_resource_id}
 EOF
 
 

--- a/oracle/datasources.tf
+++ b/oracle/datasources.tf
@@ -13,7 +13,7 @@ data "template_file" "user_data" {
     ansible_branch = var.ansible_branch
     cloud-platform = "oracle"
     fileserver-ip  = oci_file_storage_mount_target.ClusterFSMountTarget.hostname_label
-    custom_block = ""
+    custom_block = templatefile("${path.module}/files/bootstrap_custom.sh.tpl", {})
     mgmt_hostname: local.mgmt_hostname
     citc_keys = var.ssh_public_key
   }

--- a/oracle/files/bootstrap_custom.sh.tpl
+++ b/oracle/files/bootstrap_custom.sh.tpl
@@ -1,0 +1,3 @@
+dnf install -y oracle-epel-release-el8
+dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+dnf config-manager --set-enabled ol8_codeready_builder

--- a/oracle/variables.tf
+++ b/oracle/variables.tf
@@ -39,5 +39,5 @@ variable "ExportPathFS" {
 }
 
 variable "ansible_branch" {
-  default = "5"
+  default = "6"
 }


### PR DESCRIPTION
Oracle Linux 8 is now available through the standard [OCI image store](https://docs.cloud.oracle.com/en-us/iaas/images/oracle-linux-8x/). This brings all three providers to the same nominal version of the OS.