### PR TITLE
Move cleanup script to use local CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #	env REGION=europe-west4 PROJECT=myproj-123456 ZONE=europe-west4-a CREDENTIALS=myproj....json make google-test
 # Can also set ANSIBLE_BRANCH if wanted
 
-TF_VERSION := 0.12.9
+TF_VERSION := 0.14.7
 TF_VARS := terraform.*.tfvars
 TF_STATE := terraform.*.tfstate
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ azure-test.pub:
 test: oracle-test google-test
 
 validate-oracle: check-tf-version
-	./terraform init oracle
+	./terraform init -upgrade oracle
 	./terraform validate oracle
 
 oracle-config: validate-oracle
@@ -37,7 +37,7 @@ oracle-test: check-tf-version azure-test.pub oci_api_key.pem oracle-config
 
 
 validate-google: check-tf-version
-	./terraform init google
+	./terraform init -upgrade  google
 	./terraform validate google
 
 google-config: validate-google

--- a/aws/data-sources.tf
+++ b/aws/data-sources.tf
@@ -27,11 +27,3 @@ data "template_file" "startnode-yaml" {
     cluster_id: local.cluster_id
   }
 }
-
-data "local_file" "ssh_public_key" {
-  filename = pathexpand(var.public_key_path)
-}
-
-data "local_file" "ssh_private_key" {
-  filename = pathexpand(var.private_key_path)
-}

--- a/aws/data-sources.tf
+++ b/aws/data-sources.tf
@@ -7,6 +7,7 @@ data "template_file" "bootstrap-script" {
     fileserver-ip  = aws_efs_mount_target.shared.dns_name
     custom_block = templatefile("${path.module}/files/bootstrap_custom.sh.tpl", {
       dns_zone = aws_route53_zone.cluster.name
+      citc_keys = var.admin_public_keys
     })
     mgmt_hostname: local.mgmt_hostname
     citc_keys = var.admin_public_keys

--- a/aws/files/bootstrap_custom.sh.tpl
+++ b/aws/files/bootstrap_custom.sh.tpl
@@ -1,3 +1,10 @@
+# This allows the user to log into the centos provisioning account
+# with their provided keys. This is needed to debug if,
+# for example,ansible fails to run.
+cat >> /home/centos/.ssh/authorized_keys <<EOF
+${citc_keys}
+EOF
+
 dnf install -y epel-release
 dnf config-manager --set-enabled PowerTools
 hostnamectl set-hostname mgmt.${dns_zone}

--- a/aws/files/cleanup.sh
+++ b/aws/files/cleanup.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+set -euo pipefail
 
 # This script is run on cluster destruction to shut down any remaining nodes
 # and delete any lingering images

--- a/aws/files/cleanup.sh
+++ b/aws/files/cleanup.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+# This script is run on cluster destruction to shut down any remaining nodes
+# and delete any lingering images
+
+echo Terminating any remaining compute nodes
+for instance_id in $(aws ec2 describe-instances --query='Reservations[].Instances[?State.Name!=`terminated`].[InstanceId]' --filters "Name=tag:cluster,Values=${CLUSTERID}" "Name=tag:type,Values=compute" --output=text)
+do
+    aws ec2 terminate-instances --instance-ids="${instance_id}"
+done
+echo Node termination request completed
+
+echo Wiping DNS entries for hanging nodes
+hosted_zone_id=$(aws route53 list-hosted-zones --output text --query 'HostedZones[?Name==`'"${CLUSTERID}"'.citc.local.`].Id')
+# Due to the clunkiness of the route53 api, we have to reconstruct the record manually.
+# This requires the records to only have one IP in them for now.
+aws route53 list-resource-record-sets --hosted-zone-id "${hosted_zone_id}" --query 'ResourceRecordSets[?Type==`A`].[Name,TTL,ResourceRecords[0].Value]' --output=text | while read -r name_ttl_ip
+do
+  name=$(echo "${name_ttl_ip}" | cut -f1)
+  ttl=$(echo "${name_ttl_ip}" | cut -f2)
+  ip=$(echo "${name_ttl_ip}" | cut -f3)
+  if [[ "${name}" == "mgmt.${CLUSTERID}.citc.local." ]]; then
+    continue
+  fi
+  aws route53 change-resource-record-sets \
+    --hosted-zone-id $hosted_zone_id \
+    --change-batch '{"Changes":[{"Action":"DELETE","ResourceRecordSet": {"Name":"'"${name}"'", "Type":"A", "TTL":'"${ttl}"', "ResourceRecords": [{"Value":"'"${ip}"'"}]}   }]}'
+done
+echo DNS entries deleted
+
+echo Deleting any remaining compute node images
+for image_id in $(aws ec2 describe-images --filters "Name=tag:cluster,Values=${CLUSTERID}" --query 'Images[].[ImageId]' --output=text)
+do
+  aws ec2 deregister-image --image-id "${image_id}"
+done
+echo Image deletion completed

--- a/aws/provider.tf
+++ b/aws/provider.tf
@@ -23,7 +23,7 @@ provider "null" {
 }
 
 provider "aws" {
-  version     = "2.16.0"
+  version     = "3.30.0"
   profile     = var.profile  # refer to ~/.aws/credentials
   region      = var.region
 }

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -3,6 +3,3 @@ admin_public_keys = <<EOF
 ssh-rsa UmFuZG9tIGtleSBjb250ZW50cy4gUHV0IHlvdXIgb3duIGtleSBpbiBoZXJlIG9idmlvdXNseS4= user@computer
 ssh-rsa QW5vdGhlciBwdWJsaWMga2V5IGhlcmUuIEkgY2FuJ3QgYmVsaWV2ZSB5b3UgYm90aGVyZWQgdG8gZGVjb2RlIHRoaXMh user@anothercomputer
 EOF
-
-private_key_path                    = "~/.ssh/aws-key"
-public_key_path                     = "~/.ssh/aws-key.pub"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -19,14 +19,6 @@ variable "management_shape" {
   default = "t3a.medium"
 }
 
-variable "public_key_path" {
-  default = "~/.ssh/aws-key.pub"
-}
-
-variable "private_key_path" {
-  default = "~/.ssh/aws-key"
-}
-
 variable "admin_public_keys" {
   type = string
   description = "A multiline string containing the public keys used to login as the admin user"

--- a/google/compute.tf
+++ b/google/compute.tf
@@ -14,7 +14,7 @@ resource "google_compute_instance" "mgmt" {
 
   # add an ssh key that can be used to provision the instance once it's started
   metadata = {
-    ssh-keys = "provisioner:${file("citc-provisioning-key-google.pub").content}"
+    ssh-keys = "provisioner:${file("citc-provisioning-key-google.pub")}"
   }
 
   boot_disk {

--- a/google/compute.tf
+++ b/google/compute.tf
@@ -16,8 +16,8 @@ resource "google_compute_instance" "mgmt" {
   tags                    = ["mgmt-${local.cluster_id}"]
   metadata_startup_script = data.template_file.bootstrap-script.rendered
 
-  #depends_on = [module.filestore_shared_storage]
-  depends_on = [module.budget_filer_shared_storage]
+  #depends_on = [module.filestore_shared_storage, google_service_account.mgmt-sa, google_project_iam_member.mgmt-sa-computeadmin, google_project_iam_member.mgmt-sa-serviceaccountuser]
+  depends_on = [module.budget_filer_shared_storage, google_service_account.mgmt-sa, google_project_iam_member.mgmt-sa-computeadmin, google_project_iam_member.mgmt-sa-serviceaccountuser]
 
   # add an ssh key that can be used to provision the instance once it's started
   metadata = {

--- a/google/compute.tf
+++ b/google/compute.tf
@@ -78,6 +78,8 @@ resource "google_compute_instance" "mgmt" {
     command = "files/cleanup.sh"
     environment = {
       CLUSTERID = self.labels.cluster
+      PROJECT = self.project
     }
+    working_dir = path.module
   }
 }

--- a/google/compute.tf
+++ b/google/compute.tf
@@ -67,11 +67,11 @@ resource "google_compute_instance" "mgmt" {
     content     = base64decode(google_service_account_key.mgmt-sa-key.private_key)
   }
 
-  provisioner "remote-exec" {
+  provisioner "local-exec" {
     when = destroy
-    inline = [
-      "sudo -u citc /usr/local/bin/kill_all_nodes --force",
-      "sudo -u citc /usr/local/bin/cleanup_images --force",
-    ]
+    command = "files/cleanup.sh"
+    environment = {
+      CLUSTERID = self.labels.cluster
+    }
   }
 }

--- a/google/compute.tf
+++ b/google/compute.tf
@@ -48,26 +48,29 @@ resource "google_compute_instance" "mgmt" {
   }
 
   # ssh connection information for provisioning
-  connection {
-    type        = "ssh"
-    user        = "provisioner"
-    private_key = tls_private_key.provisioner_key.private_key_pem
-    host        = self.network_interface[0].access_config[0].nat_ip
-  }
-
-  provisioner "file" {
-    destination = "/tmp/shapes.yaml"
-    source      = "${path.module}/files/shapes.yaml"
-  }
 
   provisioner "file" {
     destination = "/tmp/startnode.yaml"
     content     = data.template_file.startnode-yaml.rendered
+
+    connection {
+      type        = "ssh"
+      user        = "provisioner"
+      private_key = tls_private_key.provisioner_key.private_key_pem
+      host        = self.network_interface.0.access_config.0.nat_ip
+    }
   }
 
   provisioner "file" {
     destination = "/tmp/mgmt-sa-credentials.json"
     content     = base64decode(google_service_account_key.mgmt-sa-key.private_key)
+
+    connection {
+      type        = "ssh"
+      user        = "provisioner"
+      private_key = tls_private_key.provisioner_key.private_key_pem
+      host        = self.network_interface[0].access_config[0].nat_ip
+    }
   }
 
   provisioner "local-exec" {

--- a/google/data-sources.tf
+++ b/google/data-sources.tf
@@ -1,11 +1,3 @@
-data "local_file" "ssh_private_key" {
-  filename = pathexpand(var.private_key_path)
-}
-
-data "local_file" "ssh_public_key" {
-  filename = pathexpand(var.public_key_path)
-}
-
 data "template_file" "bootstrap-script" {
   template = file("${path.module}/../common-files/bootstrap.sh.tpl")
   vars = {

--- a/google/files/cleanup.sh
+++ b/google/files/cleanup.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+# This script is run on cluster destruction to shut down any remaining nodes
+# and delete any lingering images
+
+echo Terminating any remaining compute nodes
+for instance in $(gcloud compute instances list --filter="labels.cluster=${CLUSTERID}" --format="table[no-heading](name)")
+do
+    gcloud compute instances delete "${instance}"
+done
+echo Node termination request completed
+
+echo Deleting any remaining compute node images
+for image in $(gcloud compute images list --filter="labels.cluster=${CLUSTERID}" --format="table[no-heading](name)")
+do
+    gcloud compute images delete "${image}"
+done
+echo Image deletion completed

--- a/google/files/cleanup.sh
+++ b/google/files/cleanup.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+set -euo pipefail
 
 # This script is run on cluster destruction to shut down any remaining nodes
 # and delete any lingering images

--- a/google/terraform.tfvars.example
+++ b/google/terraform.tfvars.example
@@ -11,6 +11,3 @@ admin_public_keys = <<EOF
 ssh-rsa UmFuZG9tIGtleSBjb250ZW50cy4gUHV0IHlvdXIgb3duIGtleSBpbiBoZXJlIG9idmlvdXNseS4= user@computer
 ssh-rsa QW5vdGhlciBwdWJsaWMga2V5LiBUaGVyZSByZWFsbHkgaXMgbm8gaGlkZGVuIG1lc3NhZ2UgaW4gaGVyZQ== user@anothercomputer
 EOF
-
-private_key_path                    = "~/.ssh/citc-google"
-public_key_path                     = "~/.ssh/citc-google.pub"

--- a/google/variables.tf
+++ b/google/variables.tf
@@ -70,14 +70,6 @@ variable "ansible_branch" {
   default = "6"
 }
 
-variable "private_key_path" {
-  default = "~/.ssh/citc-google"
-}
-
-variable "public_key_path" {
-  default = "~/.ssh/citc-google.pub"
-}
-
 variable "admin_public_keys" {
   type = string
   description = "A multiline string containing the public keys used to login as the admin user"

--- a/oracle/compute.tf
+++ b/oracle/compute.tf
@@ -16,6 +16,11 @@ locals {
   mgmt_hostname = "mgmt"
 }
 
+resource "tls_private_key" "provisioner_key" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P521"
+}
+
 resource "oci_core_instance" "ClusterManagement" {
   availability_domain = data.oci_identity_availability_domains.ADs.availability_domains[var.ManagementAD - 1]["name"]
   compartment_id      = var.compartment_ocid
@@ -42,7 +47,7 @@ resource "oci_core_instance" "ClusterManagement" {
   }
 
   metadata = {
-    ssh_authorized_keys = "${var.ssh_public_key}${data.tls_public_key.oci_public_key.public_key_openssh}"
+    ssh_authorized_keys = "${var.ssh_public_key}${data.tls_public_key.oci_public_key.public_key_openssh}${tls_private_key.provisioner_key.public_key_openssh}"
     user_data           = base64encode(data.template_file.user_data.rendered)
   }
 
@@ -68,9 +73,9 @@ EOF
 
     connection {
       timeout     = "15m"
-      host        = oci_core_instance.ClusterManagement.public_ip
+      host        = self.public_ip
       user        = "opc"
-      private_key = file(var.private_key_path)
+      private_key = tls_private_key.provisioner_key.private_key_pem
       agent       = false
     }
   }
@@ -81,9 +86,9 @@ EOF
 
     connection {
       timeout     = "15m"
-      host        = oci_core_instance.ClusterManagement.public_ip
+      host        = self.public_ip
       user        = "opc"
-      private_key = file(var.private_key_path)
+      private_key = tls_private_key.provisioner_key.private_key_pem
       agent       = false
     }
   }
@@ -94,9 +99,9 @@ EOF
 
     connection {
       timeout     = "15m"
-      host        = oci_core_instance.ClusterManagement.public_ip
+      host        = self.public_ip
       user        = "opc"
-      private_key = file(var.private_key_path)
+      private_key = tls_private_key.provisioner_key.private_key_pem
       agent       = false
     }
   }
@@ -111,9 +116,9 @@ EOF
 
     connection {
       timeout     = "15m"
-      host        = oci_core_instance.ClusterManagement.public_ip
+      host        = self.public_ip
       user        = "opc"
-      private_key = file(var.private_key_path)
+      private_key = tls_private_key.provisioner_key.private_key_pem
       agent       = false
     }
   }
@@ -137,12 +142,11 @@ cluster_id: ${local.cluster_id}
 mgmt_image_id: ${data.oci_core_images.ol8.images.0.id}
 EOF
 
-
 connection {
   timeout     = "15m"
-  host        = oci_core_instance.ClusterManagement.public_ip
+  host        = self.public_ip
   user        = "opc"
-  private_key = file(var.private_key_path)
+  private_key = tls_private_key.provisioner_key.private_key_pem
   agent       = false
 }
 }

--- a/oracle/compute.tf
+++ b/oracle/compute.tf
@@ -147,23 +147,13 @@ connection {
 }
 }
 
-provisioner "remote-exec" {
-  when = destroy
-  inline = [
-    "echo Terminating any remaining compute nodes",
-    "if systemctl status slurmctld >> /dev/null; then",
-    "sudo -u slurm /usr/local/bin/stopnode \"$(sinfo --noheader --Format=nodelist:10000 | tr -d '[:space:]')\" || true",
-    "fi",
-    "sleep 5",
-    "echo Node termination request completed",
-  ]
-
-  connection {
-    timeout     = "15m"
-    host        = self.public_ip
-    user        = "opc"
-    private_key = file(var.private_key_path)
-    agent       = false
+  provisioner "local-exec" {
+    when = destroy
+    command = "files/cleanup.sh"
+    environment = {
+      CLUSTERID = self.freeform_tags.cluster
+      COMPARTMENT = self.compartment_id
+    }
+    working_dir = path.module
   }
-}
 }

--- a/oracle/files/cleanup.sh
+++ b/oracle/files/cleanup.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+set -euo pipefail
 
 # This script is run on cluster destruction to shut down any remaining nodes
 # and delete any lingering images

--- a/oracle/files/cleanup.sh
+++ b/oracle/files/cleanup.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+
+# This script is run on cluster destruction to shut down any remaining nodes
+# and delete any lingering images
+
+# The commands here return something like:
+#   [
+#     "ocid1....",
+#     "ocid1...."
+#   ]
+# which we transform with head/tail/sed into:
+#   ocid1....
+#   ocid1....
+
+echo Terminating any remaining compute nodes
+for instance_id in $(oci compute instance list --compartment-id="${COMPARTMENT}" --query="data[?\"freeform-tags\".cluster==\`${CLUSTERID}\` && \"freeform-tags\".type==\`compute\`].id" | head -n-1 | tail -n+2 | sed 's/[ ",]//g')
+do
+  echo "Terminating instance ${instance_id}"
+  oci compute instance terminate --instance-id ${instance_id} --force
+done
+echo Node termination request completed
+
+echo Deleting any remaining compute node images
+for image_id in $(oci compute image list --compartment-id="${COMPARTMENT}" --query="data[?\"freeform-tags\".cluster==\`${CLUSTERID}\`].id" | head -n-1 | tail -n+2 | sed 's/[ ",]//g')
+do
+  echo "Deleting image ${image_id}"
+  oci compute image delete --image-id "${image_id}" --force
+done
+echo Image deletion completed

--- a/oracle/provider.tf
+++ b/oracle/provider.tf
@@ -1,21 +1,21 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.14"
 }
 
 provider "template" {
-  version = "~> 2.1"
+  version = "~> 2"
 }
 
 provider "tls" {
-  version = "~> 2.0"
+  version = "~> 3"
 }
 
 provider "random" {
-  version = "~> 2.2"
+  version = "~> 2"
 }
 
 provider "oci" {
-  version          = ">= 3.23.0"
+  version          = ">= 4.14.0"
 
   tenancy_ocid     = var.tenancy_ocid
   user_ocid        = var.user_ocid

--- a/test_citc.py
+++ b/test_citc.py
@@ -118,8 +118,6 @@ def create_cluster(terraform: str, provider: str, tf_vars: str, ssh_username: st
         c.run("finish", timeout=timedelta(seconds=10).seconds, in_stream=False)
         print(f" Handing over to tests...")
         yield c
-        c.run("/usr/local/bin/kill_all_nodes --force", timeout=timedelta(seconds=30).seconds, in_stream=False)
-        c.run("/usr/local/bin/cleanup_images --force", timeout=timedelta(seconds=30).seconds, in_stream=False)
 
 
 @pytest.fixture(scope="module", params=["oracle", "google", "aws"])

--- a/test_citc.py
+++ b/test_citc.py
@@ -74,7 +74,6 @@ def google_config_file(config, ssh_key) -> str:
     config = config.replace("myproj-123456", os.environ["PROJECT"])
     config = config.replace("europe-west4-a", os.environ["ZONE"])
     config = config.replace("myproj-123456-01234567890a.json", os.environ["CREDENTIALS"])
-    config = config.replace("~/.ssh/citc-google", ssh_key)
     config = config.replace("n1-standard-1", "n1-standard-1")
     with open(f"{ssh_key}.pub") as pub_key:
         pub_key_text = pub_key.read().strip()
@@ -84,7 +83,6 @@ def google_config_file(config, ssh_key) -> str:
 
 
 def aws_config_file(config, ssh_key) -> str:
-    config = config.replace("~/.ssh/aws-key", ssh_key)
     with open(f"{ssh_key}.pub") as pub_key:
         pub_key_text = pub_key.read().strip()
     config = config.replace("admin_public_keys = <<EOF", "admin_public_keys = <<EOF\n" + pub_key_text)

--- a/test_citc.py
+++ b/test_citc.py
@@ -20,13 +20,13 @@ from fabric import Connection
 def ssh_key() -> str:
     key_filename = "test_ssh_key"
     if not Path(key_filename).exists():
-        subprocess.run(["ssh-keygen", "-N", "", "-b", "4096", "-t", "rsa", "-f", key_filename], check=True)
+        subprocess.run(["ssh-keygen", "-N", "", "-t", "ed25519", "-f", key_filename], check=True)
     return key_filename
 
 
 @pytest.fixture(scope="module")
 def terraform() -> str:
-    terraform_version = "0.12.30"
+    terraform_version = "0.14.7"
     if not Path("terraform").exists():
         resp = urlopen(f"https://releases.hashicorp.com/terraform/{terraform_version}/terraform_{terraform_version}_linux_amd64.zip")
         ZipFile(BytesIO(resp.read())).extract("terraform")
@@ -98,7 +98,7 @@ def create_cluster(terraform: str, provider: str, tf_vars: str, ssh_username: st
     subprocess.run([terraform, "plan", f"-var-file={tf_vars}", f"-state={tf_state}", provider], check=True)
 
     with terraform_apply(tf_vars, tf_state, provider, terraform):
-        terraform_output = subprocess.run([terraform, "output", "-no-color", f"-state={tf_state}", "ManagementPublicIP"], capture_output=True)
+        terraform_output = subprocess.run([terraform, "output", "-no-color", f"-state={tf_state}", "-raw", "ManagementPublicIP"], capture_output=True)
         try:
             mgmt_ip = terraform_output.stdout.decode().strip()
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
As of Terraform 0.13, we can no longer access any Terraform variables during the destroy-time provisioner (see #55). We are currently using this to SSH into the management node to call a clean-up script to delete hanging nodes.

This PR changes the destroy provisioner to use the cloud CLI locally to delete hanging resources (via a script called `cleanup.sh`) instead of SSHing to the management node.

The potential issue with this is that we have to assume that the locally-running CLI's default configuration has the permission to delete the resources. There seems to be no way to pass from Terraform into the script, which credentials it is using to do its destruction.

On Google we can pull down the cluster-internal service account with `gcloud iam service-accounts keys create`, but even this depends on the default config being able to pull down that SA.

If the `cleanup.sh` script fails to destroy the resources, then the Terraform destroy will fail with a message. This means that the error should not go unnoticed, we will just have to make sure that we document how to solve the problem.

Pros:
- Allows us to update to latest version of Terraform
- We don't have to store a private key with admin permissions with the Terraform state

Cons:
- The credentials for the cloud CLI (`aws`/`gcloud`/`oci`) must be set up correctly at destroy-time. Terraform can't guarantee this

Mitigations:
- Using an (un)installer script would allow us to ensure that the credentials are set up correctly. All cloud providers not have web shells so we can expect a consistent interface.

Does any one have any thoughts on this solution?