### PR TITLE
Add new Oracle GPU shape info

### DIFF
--- a/oracle/files/shapes.yaml
+++ b/oracle/files/shapes.yaml
@@ -127,6 +127,19 @@ BM.GPU2.2:
   cores_per_socket: 14
   threads_per_core: 2
 
+BM.GPU3.8:
+  memory: 760000
+  sockets: 2
+  cores_per_socket: 28
+  threads_per_core: 2
+
+BM.GPU4.8:
+  memory: 2040000
+  sockets: 2
+  cores_per_socket: 32
+  threads_per_core: 2
+
+
 BM.Standard.E2.64:
   memory: 512000
   sockets: 2


### PR DESCRIPTION
The split in terms of sockets/cores/threads is a guess, but based on previous shapes.

Fixes #66 