### PR TITLE
Rocky8 linux

### DIFF
--- a/aws/compute.tf
+++ b/aws/compute.tf
@@ -1,11 +1,11 @@
-data "aws_ami" "centos8" {
+data "aws_ami" "rocky8" {
   # See http://cavaliercoder.com/blog/finding-the-latest-centos-ami.html
   # https://wiki.centos.org/Cloud/AWS
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["CentOS 8.*"]
+    values = ["Rocky-8*"]
   }
 
   filter {
@@ -13,7 +13,7 @@ data "aws_ami" "centos8" {
     values = ["x86_64"]
   }
 
-  owners = ["125523088429"]
+  owners = ["792107900819"] #Owner ID as stated from https://forums.rockylinux.org/t/rocky-linux-official-aws-ami/3049/25
 }
 
 locals {
@@ -26,7 +26,7 @@ resource "tls_private_key" "provisioner_key" {
 }
 
 resource "aws_instance" "mgmt" {
-  ami           = data.aws_ami.centos8.id
+  ami           = data.aws_ami.rocky8.id
   instance_type = var.management_shape
   vpc_security_group_ids = [aws_security_group.mgmt.id]
   subnet_id = aws_subnet.vpc_subnetwork.id
@@ -44,14 +44,14 @@ resource "aws_instance" "mgmt" {
 
     connection {
       type        = "ssh"
-      user        = "centos"
+      user        = "rocky"
       private_key = tls_private_key.provisioner_key.private_key_pem
       host        = self.public_ip
     }
   }
 
   provisioner "file" {
-    destination = "/home/centos/aws-credentials.csv"
+    destination = "/home/rocky/aws-credentials.csv"
     content     = <<EOF
 [default]
 aws_access_key_id = ${aws_iam_access_key.mgmt_sa.id}
@@ -60,7 +60,7 @@ EOF
 
     connection {
       type        = "ssh"
-      user        = "centos"
+      user        = "rocky"
       private_key = tls_private_key.provisioner_key.private_key_pem
       host        = self.public_ip
     }

--- a/aws/files/bootstrap_custom.sh.tpl
+++ b/aws/files/bootstrap_custom.sh.tpl
@@ -6,5 +6,5 @@ ${citc_keys}
 EOF
 
 dnf install -y epel-release
-dnf config-manager --set-enabled PowerTools
+dnf config-manager --set-enabled powertools
 hostnamectl set-hostname mgmt.${dns_zone}

--- a/aws/files/bootstrap_custom.sh.tpl
+++ b/aws/files/bootstrap_custom.sh.tpl
@@ -1,7 +1,7 @@
-# This allows the user to log into the centos provisioning account
+# This allows the user to log into the rocky provisioning account
 # with their provided keys. This is needed to debug if,
 # for example,ansible fails to run.
-cat >> /home/centos/.ssh/authorized_keys <<EOF
+cat >> /home/rocky/.ssh/authorized_keys <<EOF
 ${citc_keys}
 EOF
 


### PR DESCRIPTION
As Centos8 is End Of Life, this is a replacement to add Rocky8 Linux support to AWS on the management nodes. 

