### PR TITLE
Update the version of Ansible

### DIFF
--- a/common-files/bootstrap.sh.tpl
+++ b/common-files/bootstrap.sh.tpl
@@ -8,16 +8,22 @@ cat > /root/citc_authorized_keys <<EOF
 ${citc_keys}
 EOF
 
-yum install -y ansible git
+yum install -y git python3.11
+
+# Install Ansible
+mkdir -p /opt/venvs/
+python3.11 -m venv /opt/venvs/ansible
+/opt/venvs/ansible/bin/pip install "ansible ~= 8.0"
+
 cat > /root/hosts <<EOF
 [management]
-$(hostname -f) ansible_connection=local
+$(hostname -f) ansible_connection=local ansible_python_interpreter=/usr/bin/python3
 EOF
 
-mkdir /etc/ansible/facts.d/
+mkdir -p /etc/ansible/facts.d/
 echo "{\"csp\":\"${cloud-platform}\", \"fileserver_ip\":\"${fileserver-ip}\", \"mgmt_hostname\":\"${mgmt_hostname}\"}" > /etc/ansible/facts.d/citc.fact
 
-PYTHON=$(command -v python || command -v python3)
+
 git clone --branch "${ansible_branch}" "${ansible_repo}" /root/citc-ansible
 
 cat > /root/update_ansible_repo <<EOF
@@ -30,7 +36,8 @@ chmod +x /root/update_ansible_repo
 cat > /root/run_ansible <<EOF
 #! /bin/bash
 cd /root/citc-ansible
-/usr/bin/ansible-playbook --inventory=/root/hosts "\$@" management.yml 2>&1 | tee -a /root/ansible-pull.log
+source /opt/venvs/ansible/bin/activate
+ansible-playbook --inventory=/root/hosts "\$@" management.yml 2>&1 | tee -a /root/ansible-pull.log
 EOF
 chmod +x /root/run_ansible
 


### PR DESCRIPTION
This updates Ansible to version 8 (from version 7). Previously Ansible was installed from RPM (e.g. EPEL started providing it one day and bumped the version from 2.9 to ~7) but now we install it from PyPI (this is aided by the fact that it's now available as a wheel so installation is faster). To aid this we explicitly use a newer version of Python (new Ansible doesn't support Python 3.6 any more) and install it in a virtual environment.

Since Ansible isn't installed from RPM any more, we need to make the `/etc/ansible` directory ourselves.

Ansible also has the concept of the "control node" and the "managed node". The control node is where `ansible-playbook` is run from, and the managed node is the machine that it is affecting. You can have a different Python interpreter in those two cases (even if they are the same physical node). The Python version requirements for the managed node are lower (Python >= 3.5) and so we can have Ansible run its tasks on the system Python which is useful as that's where things like the LDAP and SELinux Python wrappers are installed. This is why we set the `ansible_python_interpreter` to `/usr/bin/python3`.

This is linked to clusterinthecloud/ansible#135